### PR TITLE
Add CLI commands to generate API definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ __pycache__/
 
 # Files generated for development
 .env
+timetracker-api-postman-collection.json
+swagger.json

--- a/README.md
+++ b/README.md
@@ -52,16 +52,16 @@ a link to the swagger.json with the definition of the api.
 
 ## CLI
 
-There are available commands aware of the API that can be verify useful for you. You
+There are available commands, aware of the API, that can be very helpful to you. You
 can check them out by running
 
-```angular2
+```
 python cli.py
 ```
 
 If you want to run an specific command, e.g. `gen_swagger_json`, specify it as a param
 as well as its correspondent options.
 
-```angular2
+```
 python cli.py gen_swagger_json -f ~/Downloads/swagger.json
 ```

--- a/README.md
+++ b/README.md
@@ -48,3 +48,20 @@ automatically [pip](https://pip.pypa.io/en/stable/) as well.
 
 - Open `http://127.0.0.1:5000/` in a browser. You will find in the presented UI 
 a link to the swagger.json with the definition of the api.
+
+
+## CLI
+
+There are available commands aware of the API that can be verify useful for you. You
+can check them out by running
+
+```angular2
+python cli.py
+```
+
+If you want to run an specific command, e.g. `gen_swagger_json`, specify it as a param
+as well as its correspondent options.
+
+```angular2
+python cli.py gen_swagger_json -f ~/Downloads/swagger.json
+```

--- a/cli.py
+++ b/cli.py
@@ -7,8 +7,9 @@ print("****************")
 import os
 
 from flask import json
-from time_tracker_api import create_app
 from flask_script import Manager
+
+from time_tracker_api import create_app
 from time_tracker_api.api import api
 
 app = create_app()
@@ -16,7 +17,9 @@ cli_manager = Manager(app)
 
 
 @cli_manager.command
-@cli_manager.option('-f', '--filename', help='Path of the swagger file. By default swagger.json')
+@cli_manager.option('-f', '--filename',
+                    dest='filename',
+                    help='Path of the swagger file. By default swagger.json')
 def gen_swagger_json(filename='swagger.json'):
     """ Exports swagger specifications in json format """
     schema_json_data = json.dumps(api.__schema__)
@@ -24,17 +27,28 @@ def gen_swagger_json(filename='swagger.json'):
 
 
 @cli_manager.command
-@cli_manager.option('-f', '--filename', dest='filename', help='Path of the postman collection file.'
-                                         'By default it is timetracker-api-postman-collection.json')
-def gen_postman_collection(filename='timetracker-api-postman-collection.json'):
+@cli_manager.option('-f', '--filename',
+                    dest='filename',
+                    help='Path of the postman collection file.'
+                         'By default it is timetracker-api-postman-collection.json')
+@cli_manager.option('-b', '--base-url-placeholder',
+                    dest='base_url_placeholder',
+                    help='Text used as placeholder. E.g. {{timetracker_api_host}}.'
+                         'By default the base url will be http://localhost')
+def gen_postman_collection(filename='timetracker-api-postman-collection.json',
+                           base_url_placeholder=None):
     """ Generates a Postman collection for the API """
     data = api.as_postman(urlvars=False, swagger=True)
     postman_collection_json_data = json.dumps(data)
-    parsed_json = postman_collection_json_data.replace("http://localhost", '{{timetracker_api_host}}')
+    if base_url_placeholder is not None:
+        parsed_json = postman_collection_json_data.replace("http://localhost", base_url_placeholder)
+    else:
+        parsed_json = postman_collection_json_data
+
     save_data(parsed_json, filename)
 
 
-def save_data(data, filename):
+def save_data(data: str, filename: str) -> None:
     """ Save text content to a file """
     if filename:
         try:

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+print("****************")
+print("TimeTracker CLI")
+print("****************")
+
+import os
+
+from flask import json
+from time_tracker_api import create_app
+from flask_script import Manager
+from time_tracker_api.api import api
+
+app = create_app()
+cli_manager = Manager(app)
+
+
+@cli_manager.command
+@cli_manager.option('-f', '--filename', help='Path of the swagger file. By default swagger.json')
+def gen_swagger_json(filename='swagger.json'):
+    """ Exports swagger specifications in json format """
+    schema_json_data = json.dumps(api.__schema__)
+    save_data(schema_json_data, filename)
+
+
+@cli_manager.command
+@cli_manager.option('-f', '--filename', dest='filename', help='Path of the postman collection file.'
+                                         'By default it is timetracker-api-postman-collection.json')
+def gen_postman_collection(filename='timetracker-api-postman-collection.json'):
+    """ Generates a Postman collection for the API """
+    data = api.as_postman(urlvars=False, swagger=True)
+    postman_collection_json_data = json.dumps(data)
+    parsed_json = postman_collection_json_data.replace("http://localhost", '{{timetracker_api_host}}')
+    save_data(parsed_json, filename)
+
+
+def save_data(data, filename):
+    """ Save text content to a file """
+    if filename:
+        try:
+            real_path = os.path.expanduser(filename)
+            with open(real_path, "w") as f:
+                f.write(data)
+                print("%s was generated successfully" % real_path)
+        except OSError as err:
+            print("Error while generating '%s': %s" % filename, err)
+    else:
+        print(data)
+
+
+if __name__ == "__main__":
+    cli_manager.run()

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,5 +1,19 @@
+# requirements/prod.txt
+
+# For production releases
+
+#Required by Flask
 Flask==1.1.1
-flask-restplus==0.13.0
 flake8==3.7.9
+WSGIserver==1.3
 Werkzeug==0.16.1
+Jinja2==2.11.1
+
+#WSGI server
 gunicorn==20.0.4
+
+#Swagger support for Restful API
+flask-restplus==0.13.0
+
+#CLI support
+Flask-Script==2.0.6

--- a/run.py
+++ b/run.py
@@ -5,4 +5,4 @@ This file is needed by gunicorn to run
 from time_tracker_api import create_app
 
 app = create_app()
-print("BPM Projects API server was created")
+print("TimeTracker API server was created")


### PR DESCRIPTION
This PR makes possible to run CLI commands:
- gen_swagger_json: Exports swagger specifications in JSON format, namely swagger.json
- gen_postman_collection: Generates a Postman Collection for the API

Check out the README for better information.