### PR TITLE
Fixes #18 - create common structure and use it across models

### DIFF
--- a/time_tracker_api/activities/activities_api.py
+++ b/time_tracker_api/activities/activities_api.py
@@ -1,4 +1,5 @@
 from flask_restplus import fields, Resource, Namespace
+from time_tracker_api.api import audit_fields
 
 ns = Namespace('activities', description='API for activities')
 
@@ -16,31 +17,21 @@ activity = ns.model('Activity', {
     ),
 })
 
-activity_response = ns.inherit('ActivityResponse', activity, {
+activity_response_fields = {
     'id': fields.String(
         readOnly=True,
         required=True,
         title='Identifier',
         description='The unique identifier',
-    ),
-    'created_at': fields.Date(
-        readOnly=True,
-        title='Created',
-        description='Date of creation'
-    ),
-    'created_by': fields.String(
-        readOnly=True,
-        title='Creator',
-        max_length=64,
-        description='User that created it',
-    ),
-    'tenant_id': fields.String(
-        readOnly=True,
-        title='Tenant',
-        max_length=64,
-        description='The tenant this belongs to',
-    ),
-})
+    )
+}
+activity_response_fields.update(audit_fields)
+
+activity_response = ns.inherit(
+    'ActivityResponse',
+    activity,
+    activity_response_fields
+)
 
 
 @ns.route('')

--- a/time_tracker_api/api.py
+++ b/time_tracker_api/api.py
@@ -1,8 +1,28 @@
-
-from flask_restplus import Api
+from flask_restplus import Api, fields
 
 api = Api(version='1.0.1', title="TimeTracker API",
           description="API for the TimeTracker project")
+
+# Common models structure
+audit_fields = {
+    'created_at': fields.Date(
+        readOnly=True,
+        title='Created',
+        description='Date of creation'
+    ),
+    'tenant_id': fields.String(
+        readOnly=True,
+        title='Tenant',
+        max_length=64,
+        description='The tenant this belongs to',
+    ),
+    'created_by': fields.String(
+        readOnly=True,
+        title='Creator',
+        max_length=64,
+        description='User that created it',
+    ),
+}
 
 # APIs
 from time_tracker_api.projects import projects_api

--- a/time_tracker_api/projects/projects_api.py
+++ b/time_tracker_api/projects/projects_api.py
@@ -1,6 +1,7 @@
 from flask_restplus import Namespace, Resource, abort, inputs, fields
 from .projects_model import project_dao
 from time_tracker_api.errors import MissingResource
+from time_tracker_api.api import audit_fields
 
 ns = Namespace('projects', description='API for projects (clients)')
 
@@ -24,26 +25,21 @@ project = ns.model('Project', {
     ),
 })
 
-
-project_response = ns.inherit('ProjectResponse', project, {
+project_response_fields = {
     'id': fields.String(
         readOnly=True,
         required=True,
         title='Identifier',
         description='The unique identifier',
-    ),
-    'created_at': fields.Date(
-        readOnly=True,
-        title='Created',
-        description='Date of creation'
-    ),
-    'tenant_id': fields.String(
-        readOnly=True,
-        title='Tenant',
-        max_length=64,
-        description='The tenant this belongs to',
-    ),
-})
+    )
+}
+project_response_fields.update(audit_fields)
+
+project_response = ns.inherit(
+    'ProjectResponse',
+    project,
+    project_response_fields
+)
 
 
 @ns.route('')

--- a/time_tracker_api/technologies/technologies_api.py
+++ b/time_tracker_api/technologies/technologies_api.py
@@ -1,4 +1,5 @@
 from flask_restplus import Namespace, Resource, fields
+from time_tracker_api.api import audit_fields
 
 ns = Namespace('technologies', description='API for technologies used')
 
@@ -12,31 +13,21 @@ technology = ns.model('Technology', {
     ),
 })
 
-technology_response = ns.inherit('TechnologyResponse', technology, {
+technology_response_fields = {
     'id': fields.String(
         readOnly=True,
         required=True,
         title='Identifier',
         description='The unique identifier',
     ),
-    'created_at': fields.Date(
-        readOnly=True,
-        title='Created',
-        description='Date of creation'
-    ),
-    'created_by': fields.String(
-        readOnly=True,
-        title='Creator',
-        max_length=64,
-        description='User that created it',
-    ),
-    'tenant_id': fields.String(
-        readOnly=True,
-        title='Tenant',
-        max_length=64,
-        description='The tenant this belongs to',
-    ),
-})
+}
+technology_response_fields.update(audit_fields)
+
+technology_response = ns.inherit(
+    'TechnologyResponse',
+    technology,
+    technology_response_fields
+)
 
 
 @ns.route('')

--- a/time_tracker_api/time_entries/time_entry_api.py
+++ b/time_tracker_api/time_entries/time_entry_api.py
@@ -1,4 +1,5 @@
 from flask_restplus import fields, Resource, Namespace
+from time_tracker_api.api import audit_fields
 
 ns = Namespace('time-entries', description='API for time entries')
 
@@ -38,7 +39,7 @@ time_entry = ns.model('TimeEntry', {
     ),
 })
 
-time_entry_response = ns.inherit('TimeEntryResponse', time_entry, {
+time_entry_response_fields = {
     'id': fields.String(
         readOnly=True,
         required=True,
@@ -50,24 +51,14 @@ time_entry_response = ns.inherit('TimeEntryResponse', time_entry, {
         title='Is it running?',
         description='Whether this time entry is currently running or not'
     ),
-    'created_at': fields.Date(
-        readOnly=True,
-        title='Created',
-        description='Date of creation'
-    ),
-    'created_by': fields.String(
-        readOnly=True,
-        title='Creator',
-        max_length=64,
-        description='User that created it',
-    ),
-    'tenant_id': fields.String(
-        readOnly=True,
-        title='Tenant',
-        max_length=64,
-        description='The tenant this belongs to',
-    ),
-})
+}
+time_entry_response_fields.update(audit_fields)
+
+time_entry_response = ns.inherit(
+    'TimeEntryResponse',
+    time_entry,
+    time_entry_response_fields,
+)
 
 
 @ns.route('')


### PR DESCRIPTION
We define a model structure for each model, which contains fields. Some of those fields are shared for almost all models. Those fields are specifically for auditing the  model (e.g. `created_at`, `created_by`, `tenant_id`). This PR created a common structure for those fields and reuse it across several models.