### PR TITLE
Solve #46 by using standard naming of env vars 

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -13,6 +13,3 @@ Faker==4.0.2
 
 # Coverage
 coverage==4.5.1
-
-# The Debug Toolbar
-Flask-DebugToolbar==0.11.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -29,3 +29,6 @@ flask_sqlalchemy==2.4.1
 
 # Handling requests
 requests==2.23.0
+
+# The Debug Toolbar
+Flask-DebugToolbar==0.11.0

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -5,12 +5,11 @@ from flask.testing import FlaskClient
 from flask_restplus._http import HTTPStatus
 from pytest_mock import MockFixture
 
+unexpected_errors_to_be_handled = [pyodbc.OperationalError]
+
 
 def test_app_exists(app):
     assert app is not None
-
-
-unexpected_errors_to_be_handled = [pyodbc.OperationalError]
 
 
 @pytest.mark.parametrize("error_type", unexpected_errors_to_be_handled)

--- a/time_tracker_api/config.py
+++ b/time_tracker_api/config.py
@@ -2,6 +2,8 @@ import os
 
 from time_tracker_api.security import generate_dev_secret_key
 
+DISABLE_STR_VALUES = ("false", "0", "disabled")
+
 
 class Config:
     SECRET_KEY = generate_dev_secret_key()
@@ -32,13 +34,14 @@ class TestConfig(SQLConfig):
 
 
 class ProductionConfig(Config):
-    DEBUG = False
+    DEBUG = os.environ.get('DEBUG', "false").lower() not in DISABLE_STR_VALUES
     FLASK_DEBUG = True
     FLASK_ENV = 'production'
 
 
 class AzureConfig(SQLConfig):
-    DATABASE_URI = os.environ.get('SQLAZURECONNSTR_DATABASE_URI')
+    DATABASE_URI = os.environ.get('DATABASE_URI', os.environ.get('SQLAZURECONNSTR_DATABASE_URI'))
+    SQLALCHEMY_DATABASE_URI = DATABASE_URI
 
 
 class AzureDevelopmentConfig(DevelopmentConfig, AzureConfig):


### PR DESCRIPTION
It fixes the user of env variables in Azure. In addition, having into account that all variables we set are gotten in Python as strings, e.g. `True` we need to set a convention to what is a Truthy or a falsy value. So I decided to basically allow to specify some falsy discrete values, which are:

- `false`
- `0`
- `disabled`

Any different string to those ones (case-insensitive) will be considered as True. These values will be contained in the constant `time_tracker_api.config.DISABLE_STR_VALUES`.